### PR TITLE
Fix: Don't throw on compression error

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -21,7 +21,7 @@ function BrotliPlugin (api, options) {
         compressFile(file, { ...options, outputDir }, err => err ? reject(err) : resolve())
       })
     })
-    await Promise.all(compress)
+    const results = await Promise.allSettled(compress)
     workerFarm.end(compressFile)
 
     const tmrEnd = new Date().getTime()

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -24,8 +24,21 @@ function BrotliPlugin (api, options) {
     const results = await Promise.allSettled(compress)
     workerFarm.end(compressFile)
 
-    const tmrEnd = new Date().getTime()
-    console.log(`Brotli compressed ${files.length} files in ${(tmrEnd - tmrStart) / 1000} s`)
+    const tmrEnd = new Date().getTime();
+
+    const failedFiles = results
+      .map((result, index) => ({ result, file: files[index] }))
+      .filter((result) => result.status === 'rejected');
+    const failReport = failedFiles.length
+      ? '\nThese files failed:'
+        + failedFiles.map(({ file, result }) => `\nFile: ${file} \nReason: ${result.reason}`).join('\n') 
+      : '';
+
+    const compressedCount = files.length - failedFiles.length;
+    console.log(
+      `Brotli compressed ${compressedCount}/${files.length} files in ${(tmrEnd - tmrStart) / 1000} s`
+      + failReport
+    );
   })
 }
 


### PR DESCRIPTION
Use `Promise.allSettled` instead of `Promise.all`, to allow the build to go to completion even if any one of the files fails to be compressed.

And to give users visibility into the failed files, print them out at the end